### PR TITLE
Replaced OneMobileSDK pod with OathVideoPartnerSDK

### DIFF
--- a/NewTutorials/Podfile
+++ b/NewTutorials/Podfile
@@ -2,10 +2,10 @@ source 'https://github.com/vidible/OneMobileSDK-releases.git'
 
 target 'Tutorial' do
 	platform :ios, 9.0
-  	pod 'OneMobileSDK-Xcode9.3'
+  	pod 'OathVideoPartnerSDK'
 end
 
 target 'Tutorial_tvOS' do
 	platform :tvos, 9.0
-  	pod 'OneMobileSDK-Xcode9.3'
+  	pod 'OathVideoPartnerSDK'
 end

--- a/NewTutorials/Podfile.lock
+++ b/NewTutorials/Podfile.lock
@@ -1,16 +1,28 @@
 PODS:
-  - OneMobileSDK-Xcode9.3 (2.28.2631)
+  - OathVideoPartnerSDK (1.0):
+    - PlayerControls (= 1.26)
+    - PlayerCore (= 1.0.1)
+    - VideoRenderer (= 1.24)
+  - PlayerControls (1.26)
+  - PlayerCore (1.0.1)
+  - VideoRenderer (1.24)
 
 DEPENDENCIES:
-  - OneMobileSDK-Xcode9.3
+  - OathVideoPartnerSDK
 
 SPEC REPOS:
   https://github.com/vidible/OneMobileSDK-releases.git:
-    - OneMobileSDK-Xcode9.3
+    - OathVideoPartnerSDK
+    - PlayerControls
+    - PlayerCore
+    - VideoRenderer
 
 SPEC CHECKSUMS:
-  OneMobileSDK-Xcode9.3: 3507ad42d6927226e9d9ebf245d9ab3f2c6652ac
+  OathVideoPartnerSDK: ebf23f8d27f446438bcc403677d49fed91790bfd
+  PlayerControls: fc31fd5b9c6390e1811342a5cfb1d714d438847c
+  PlayerCore: 191a3eb26414872fbc658420953c751d9ab960e4
+  VideoRenderer: a537af56ec8b1666cc0cd7d6d61ca43b88ecb1d0
 
-PODFILE CHECKSUM: 47046a146d8a0758a7f712e3e3c9dc7ab98c8b72
+PODFILE CHECKSUM: 378a74bd88392e1a737e19096657353d8b3a14a0
 
 COCOAPODS: 1.5.3

--- a/NewTutorials/Tutorial.xcodeproj/project.pbxproj
+++ b/NewTutorials/Tutorial.xcodeproj/project.pbxproj
@@ -201,7 +201,7 @@
 				DA63A2391FF3FD8F0044B40F /* Sources */,
 				DA63A23A1FF3FD8F0044B40F /* Frameworks */,
 				DA63A23B1FF3FD8F0044B40F /* Resources */,
-				219299DCB08013F865A7F8F0 /* [CP] Embed Pods Frameworks */,
+				B255D7A18B76F06DC5648411 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -220,7 +220,7 @@
 				DA8175E51FE7D3B300A3A381 /* Sources */,
 				DA8175E61FE7D3B300A3A381 /* Frameworks */,
 				DA8175E71FE7D3B300A3A381 /* Resources */,
-				18391BF94DD82ED70CB20F59 /* [CP] Embed Pods Frameworks */,
+				E75ADA242E6CDFC508B27059 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -293,66 +293,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		18391BF94DD82ED70CB20F59 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial/Pods-Tutorial-frameworks.sh",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/OneMobileSDK.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/OneMobileSDK.framework.dSYM",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/PlayerControls.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/PlayerControls.framework.dSYM",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/PlayerCore.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/PlayerCore.framework.dSYM",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/VideoRenderer.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/iOS/VideoRenderer.framework.dSYM",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OneMobileSDK.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/OneMobileSDK.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayerControls.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/PlayerControls.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayerCore.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/PlayerCore.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VideoRenderer.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/VideoRenderer.framework.dSYM",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial/Pods-Tutorial-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		219299DCB08013F865A7F8F0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial_tvOS/Pods-Tutorial_tvOS-frameworks.sh",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/OneMobileSDK.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/OneMobileSDK.framework.dSYM",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/PlayerCore.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/PlayerCore.framework.dSYM",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/VideoRenderer.framework",
-				"${PODS_ROOT}/OneMobileSDK-Xcode9.3/Carthage/Build/tvOS/VideoRenderer.framework.dSYM",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OneMobileSDK.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/OneMobileSDK.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PlayerCore.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/PlayerCore.framework.dSYM",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/VideoRenderer.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/VideoRenderer.framework.dSYM",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial_tvOS/Pods-Tutorial_tvOS-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		2599062A3578C6A971EF10E3 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -387,6 +327,58 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B255D7A18B76F06DC5648411 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial_tvOS/Pods-Tutorial_tvOS-resources.sh",
+				"${PODS_ROOT}/OathVideoPartnerSDK/support/OathVideoPartnerSDK-Version.plist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/OathVideoPartnerSDK-Version.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial_tvOS/Pods-Tutorial_tvOS-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E75ADA242E6CDFC508B27059 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial/Pods-Tutorial-resources.sh",
+				"${PODS_ROOT}/OathVideoPartnerSDK/support/OathVideoPartnerSDK-Version.plist",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/AdVideoControls.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/AirPlayActiveView.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/DefaultControlsViewController.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/SeekerControlPlayground.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/SettingCell.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/SettingHeaderView.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/SettingsViewController.xib",
+				"${PODS_ROOT}/PlayerControls/PlayerControls/resources/PlayerUIControls.xcassets",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/OathVideoPartnerSDK-Version.plist",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AdVideoControls.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AirPlayActiveView.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/DefaultControlsViewController.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SeekerControlPlayground.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SettingCell.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SettingHeaderView.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/SettingsViewController.nib",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Assets.car",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Tutorial/Pods-Tutorial-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -456,7 +448,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CY9THR77Q9;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				INFOPLIST_FILE = Tutorial_tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aol.mobile.one.testapp;
@@ -475,7 +467,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = CY9THR77Q9;
+				DEVELOPMENT_TEAM = 7V23547MMU;
 				INFOPLIST_FILE = Tutorial_tvOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.aol.mobile.one.testapp;

--- a/NewTutorials/Tutorial/Base.lproj/Main.storyboard
+++ b/NewTutorials/Tutorial/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kvZ-eG-HbE">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kvZ-eG-HbE">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -335,7 +335,7 @@
         <!--Player View Controller-->
         <scene sceneID="wdZ-8h-SuS">
             <objects>
-                <viewController id="mw1-k1-5o6" customClass="PlayerViewController" customModule="OneMobileSDK" sceneMemberID="viewController">
+                <viewController id="mw1-k1-5o6" customClass="PlayerViewController" customModule="OathVideoPartnerSDK" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="eYU-aX-K1W">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/NewTutorials/Tutorial/PlayerViewControllerWrapper.swift
+++ b/NewTutorials/Tutorial/PlayerViewControllerWrapper.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2017 Oath. All rights reserved.
 
 import UIKit
-import OneMobileSDK
+import OathVideoPartnerSDK
 import PlayerControls
 
 

--- a/NewTutorials/Tutorial/Players.swift
+++ b/NewTutorials/Tutorial/Players.swift
@@ -1,23 +1,23 @@
 //  Copyright © 2017 Oath. All rights reserved.
 
 import Foundation
-import OneMobileSDK
+import OathVideoPartnerSDK
 
 func singleVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "577cc23d50954952cc56bc47") }
 }
 
 #if os(iOS)
 func arrayOfVideos() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoIDs: ["593967be9e45105fa1b5939a",
                                         "577cc23d50954952cc56bc47",
                                         "5939698f85eb427b86aa0a14"]) }
 }
 
 func videoPlaylist() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(playlistID: "577cc27b88d2ff0d0f5acc71") }
 }
 #endif
@@ -28,32 +28,32 @@ func mutedVideo() -> Future<Result<Player>> {
 }
 
 func videoWithoutAutoplay() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "577cc23d50954952cc56bc47",
                              autoplay: false) }
 }
 
 func liveVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "5a600ab092fdde68e1f7a606") }
 }
 
 func subtitlesVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "59397934955a316f1c4f65b4") }
 }
 
 func restrictedVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "59396b1c9e45105fa1b599c9") }
 }
 
 func deletedVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "577cc23d50954952cc56bc48") }
 }
 
 func unknownVideo() -> Future<Result<Player>> {
-    return OneSDK.Provider.default.getSDK()
+    return OVPSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "unknown") }
 }

--- a/NewTutorials/Tutorial/SetupTutorials.swift
+++ b/NewTutorials/Tutorial/SetupTutorials.swift
@@ -1,7 +1,7 @@
 //  Copyright © 2017 Oath. All rights reserved.
 
 import UIKit
-import OneMobileSDK
+import OathVideoPartnerSDK
 import PlayerControls
 
 

--- a/NewTutorials/Tutorial_tvOS/Base.lproj/Main.storyboard
+++ b/NewTutorials/Tutorial_tvOS/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="13771" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Oev-Oj-FJH">
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="14113" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Oev-Oj-FJH">
     <device id="appleTV" orientation="landscape">
         <adaptation id="light"/>
     </device>
     <dependencies>
         <deployment identifier="tvOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="TextCell" id="OPr-af-YQd" customClass="TextCell" customModule="Tutorial_tvOS" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="66" width="1700" height="66"/>
+                                <rect key="frame" x="110" y="66" width="1700" height="66"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="OPr-af-YQd" id="k1t-Gd-vM0">
                                     <rect key="frame" x="0.0" y="0.0" width="1700" height="66"/>
@@ -109,7 +109,7 @@
         <!--System Player View Controller-->
         <scene sceneID="Yv8-Au-BRW">
             <objects>
-                <viewController id="fuC-Io-VD4" customClass="SystemPlayerViewController" customModule="OneMobileSDK" sceneMemberID="viewController">
+                <viewController id="fuC-Io-VD4" customClass="SystemPlayerViewController" customModule="OathVideoPartnerSDK" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="5Mh-aC-hAy"/>
                         <viewControllerLayoutGuide type="bottom" id="BU8-Wn-AuI"/>

--- a/NewTutorials/Tutorial_tvOS/Info.plist
+++ b/NewTutorials/Tutorial_tvOS/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SDK Tutorials</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/NewTutorials/Tutorial_tvOS/SetupTutorials.swift
+++ b/NewTutorials/Tutorial_tvOS/SetupTutorials.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 import CoreImage
-import OneMobileSDK
+import OathVideoPartnerSDK
 
 func setup(tutorialCasesViewController: TutorialCasesViewController) {
     func select(player: Future<Result<Player>>, filter: CIFilter? = nil) -> (UIViewController) -> () {

--- a/NewTutorials/Tutorial_tvOS/SystemPlayerViewControllerWrapper.swift
+++ b/NewTutorials/Tutorial_tvOS/SystemPlayerViewControllerWrapper.swift
@@ -2,7 +2,7 @@
 
 import UIKit
 import CoreImage
-import OneMobileSDK
+import OathVideoPartnerSDK
 
 
 class SystemPlayerViewControllerWrapper: UIViewController {


### PR DESCRIPTION
## Changes
- Added `OathVideoPartnerSDK` pod instead of `OneMobileSDK` including all dependencies.
- Updated project files.
- Updated main class from `OneSDK` to `OVPSDK`.
- Updated storyboards with a new module.

@aol-public/mobile-sdk-team Ready for review!