### PR TITLE
Added sample of ads only player with disabled controls and short video 

### DIFF
--- a/NewTutorials/Tutorial/PlayerViewControllerWrapper.swift
+++ b/NewTutorials/Tutorial/PlayerViewControllerWrapper.swift
@@ -17,6 +17,7 @@ class PlayerViewControllerWrapper: UIViewController {
             var isFilteredSubtitles = false
             var isAnimationsDisabled = false
             var isCustomColorsMode = false
+            var areContentControlsDisabled = false
         }
         
         var showStats = false
@@ -165,6 +166,10 @@ class PlayerViewControllerWrapper: UIViewController {
                 guard strongSelf.props.controls.isAnimationsDisabled else { return }
                 controls.animationsEnabled = false
             }
+            func disabledControls() {
+                guard strongSelf.props.controls.areContentControlsDisabled else { return }
+                strongSelf.playerViewController?.contentControlsViewController = nil
+            }
             func customSeekbarColors() {
                 guard strongSelf.props.controls.isCustomColorsMode else { return }
                 //Constructor have default values, so you can setup only those elements that you want
@@ -215,6 +220,7 @@ class PlayerViewControllerWrapper: UIViewController {
             hideSomeControls()
             filteredSubtitles()
             disabledAnimations()
+            disabledControls()
             customSeekbarColors()
             
             contentPlayer.playlist?.next = customNextCommand

--- a/NewTutorials/Tutorial/Players.swift
+++ b/NewTutorials/Tutorial/Players.swift
@@ -7,6 +7,10 @@ func singleVideo() -> Future<Result<Player>> {
     return OneSDK.Provider.default.getSDK()
         .then { $0.getPlayer(videoID: "577cc23d50954952cc56bc47") }
 }
+func shortVideo() -> Future<Result<Player>> {
+    return OneSDK.Provider.default.getSDK()
+        .then { $0.getPlayer(videoID: "5ade13e620565f4be5e35c72") }
+}
 
 #if os(iOS)
 func arrayOfVideos() -> Future<Result<Player>> {

--- a/NewTutorials/Tutorial/SetupTutorials.swift
+++ b/NewTutorials/Tutorial/SetupTutorials.swift
@@ -66,6 +66,11 @@ func setupCustomUX(tutorialCasesViewController: TutorialCasesViewController) {
         wrapper.player = singleVideo()
     }
     
+    func disabledControls(wrapper: PlayerViewControllerWrapper) {
+        wrapper.props.controls.areContentControlsDisabled = true
+        wrapper.player = shortVideo()
+    }
+    
     func customSeekerColors(wrapper: PlayerViewControllerWrapper) {
         wrapper.props.controls.isCustomColorsMode = true
         wrapper.player = singleVideo()
@@ -78,6 +83,7 @@ func setupCustomUX(tutorialCasesViewController: TutorialCasesViewController) {
                .init(name: "Live dot color", select: select(controller: liveDotColor)),
                .init(name: "Filtered subtitles", select: select(controller: filteredSubtitles)),
                .init(name: "Disabled Animations", select: select(controller: disabledAnimations)),
+               .init(name: "Ads Only player", select: select(controller: disabledControls)),
                .init(name: "Custom seeker colors", select: select(controller: customSeekerColors))])
 }
 


### PR DESCRIPTION
## Notes
In this test case, we've totally turned off controls for the content player. And the `video id`, that we use is very very short with a dark background, so it ends right after the ad is finished.
The player itself can be shown, for example, whenever the `isAdPlaying` value in `props` is `true`. 
This is an easy example of how it can be done, without doing any changes in our SDK.

## Demo
![ads-only-giph](https://user-images.githubusercontent.com/31652265/47293210-29922880-d612-11e8-855b-022fb992af44.gif)
